### PR TITLE
Properly escape tool description to avoid malformed `Markup` object (…

### DIFF
--- a/shell/AIShell.Kernel/Host.cs
+++ b/shell/AIShell.Kernel/Host.cs
@@ -580,7 +580,7 @@ internal sealed class Host : IHost
 
             [bold]Run [olive]{tool.OriginalName}[/] from [olive]{tool.ServerName}[/] (MCP server)[/]
 
-            {tool.Description}
+            {tool.Description.EscapeMarkup()}
 
             Input:{(hasArgs ? string.Empty : " <none>")}
             """);


### PR DESCRIPTION
…#408)